### PR TITLE
Fix orientation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
 
         <activity
             android:name=".MainActivity"
+            android:screenOrientation="portrait"
             android:exported="true"
             android:windowSoftInputMode="adjustPan">
             <intent-filter>

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         // Add the dependency for the Google services Gradle plugin
         classpath 'com.google.gms:google-services:4.3.15'
-
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 plugins {


### PR DESCRIPTION
Soooo you know how our app crashes when we switch orientation (portrait vs. landscape), right? Since our app isn't even functional in landscape (a lot gets cut off), I just disabled landscape! I know, me so smart uwu.